### PR TITLE
Improve wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Branch source aged refs traits
 
-This repo is a collection of traits for several branch-source Jenkins plugins.
+This repository contains a collection of traits for several branch-source Jenkins plugins.
 
 It provides filters for
- - GitHub: Filtering references (branches and pull requests) 
+ - GitHub: Filtering references (branches and pull requests)
  - Bitbucket: Filtering references (branches and pull requests)
 
-
-The filtering will be performed matching a threshold (in days) with each ref last commit modification date.
+The filtering will be performed matching a threshold (in days) with each ref's last commit modification date.

--- a/scm-filter-aged-refs-common/src/main/java/org/jenkinsci/plugins/scm_filter/AgedRefsTrait.java
+++ b/scm-filter-aged-refs-common/src/main/java/org/jenkinsci/plugins/scm_filter/AgedRefsTrait.java
@@ -52,7 +52,7 @@ public abstract class AgedRefsTrait extends SCMSourceTrait{
          */
         @Override
         public String getDisplayName() {
-            return "Aged refs filter";
+            return "Filter by ref age";
         }
 
 


### PR DESCRIPTION
Use verb "Filter" as prefix (not as postfix noun) to comply with other behaviours (e.g. "Filter by name..." from scm-api-plugin).