### PR TITLE
Fix trait filtering (GitHub vs. Bitbucket)

### DIFF
--- a/bitbucket-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketAgedRefsTrait.java
+++ b/bitbucket-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/BitbucketAgedRefsTrait.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.scm_filter;
 
-import com.cloudbees.jenkins.plugins.bitbucket.BitbucketGitSCMBuilder;
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceContext;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
@@ -9,7 +10,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import org.jenkinsci.Symbol;
@@ -46,12 +47,14 @@ public class BitbucketAgedRefsTrait extends AgedRefsTrait {
     @SuppressWarnings("unused") // instantiated by Jenkins
     public static class DescriptorImpl extends AgedRefsDescriptorImpl {
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
-        public boolean isApplicableToBuilder(@NonNull Class<? extends SCMBuilder> builderClass) {
-            return BitbucketGitSCMBuilder.class.isAssignableFrom(builderClass);
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return BitbucketSCMSourceContext.class;
+        }
+
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return BitbucketSCMSource.class;
         }
     }
 

--- a/github-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubAgedRefsTrait.java
+++ b/github-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubAgedRefsTrait.java
@@ -3,12 +3,13 @@ package org.jenkinsci.plugins.scm_filter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.github_branch_source.BranchSCMHead;
-import org.jenkinsci.plugins.github_branch_source.GitHubSCMBuilder;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceContext;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceRequest;
 import org.jenkinsci.plugins.github_branch_source.GitHubTagSCMHead;
 import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
@@ -47,12 +48,14 @@ public class GitHubAgedRefsTrait extends AgedRefsTrait {
     @SuppressWarnings("unused") // instantiated by Jenkins
     public static class DescriptorImpl extends AgedRefsDescriptorImpl {
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
-        public boolean isApplicableToBuilder(@NonNull Class<? extends SCMBuilder> builderClass) {
-            return GitHubSCMBuilder.class.isAssignableFrom(builderClass);
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitHubSCMSourceContext.class;
+        }
+
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitHubSCMSource.class;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
                 <version>1.16</version>
             </dependency>
             <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>structs</artifactId>
+                <version>1.10</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>
                 <version>1.13</version>

--- a/scm-filter-aged-refs-common/pom.xml
+++ b/scm-filter-aged-refs-common/pom.xml
@@ -15,6 +15,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>

--- a/scm-filter-aged-refs-common/src/main/java/org/jenkinsci/plugins/scm_filter/AgedRefsTrait.java
+++ b/scm-filter-aged-refs-common/src/main/java/org/jenkinsci/plugins/scm_filter/AgedRefsTrait.java
@@ -1,8 +1,6 @@
 package org.jenkinsci.plugins.scm_filter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.plugins.git.GitSCM;
-import hudson.scm.SCMDescriptor;
 import hudson.util.FormValidation;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.trait.SCMHeadFilter;
@@ -75,14 +73,6 @@ public abstract class AgedRefsTrait extends SCMSourceTrait {
             }
 
             return formValidation;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean isApplicableToSCM(@NonNull SCMDescriptor<?> scm) {
-            return scm instanceof GitSCM.DescriptorImpl;
         }
     }
 


### PR DESCRIPTION
Currently there is the problem, that the GitHub behaviour is also selectable for Bitbucket sources and vice versa.

After this change the traits for GitHub are only visible for GitHub and the traits for Bitbucket are only visible for Bitbucket sources.