### PR TITLE
Restrict form validation to POST

### DIFF
--- a/scm-filter-aged-refs-common/src/main/java/org/jenkinsci/plugins/scm_filter/AgedRefsTrait.java
+++ b/scm-filter-aged-refs-common/src/main/java/org/jenkinsci/plugins/scm_filter/AgedRefsTrait.java
@@ -12,6 +12,7 @@ import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 public abstract class AgedRefsTrait extends SCMSourceTrait {
 
@@ -46,6 +47,7 @@ public abstract class AgedRefsTrait extends SCMSourceTrait {
         }
 
         @Restricted(NoExternalUse.class)
+        @POST
         public FormValidation doCheckRetentionDays(@QueryParameter String value) {
             FormValidation formValidation = FormValidation.ok();
 


### PR DESCRIPTION
If the form validation did anything interesting, this would be a security issue. 😉 

As such, this is only a minor code smell.