### PR TITLE
Use correct "latest commit date" for GitHub PRs

### DIFF
--- a/github-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubAgedRefsTrait.java
+++ b/github-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubAgedRefsTrait.java
@@ -96,16 +96,18 @@ public class GitHubAgedRefsTrait extends AgedRefsTrait {
                         .findAny();
                 if (pull.isPresent()) {
                     PagedIterator<GHPullRequestCommitDetail> iterator =
-                            pull.get().listCommits().withPageSize(1).iterator();
-                    // Has at least one commit
-                    if (iterator.hasNext()) {
-                        long pullTS = iterator.next()
+                            pull.get().listCommits().iterator();
+                    long latestPullTS = 0;
+                    while (iterator.hasNext()) {
+                        long commitTS = iterator.next()
                                 .getCommit()
                                 .getCommitter()
                                 .getDate()
                                 .getTime();
-                        return pullTS < super.getAcceptableDateTimeThreshold();
+                        if (commitTS > latestPullTS) latestPullTS = commitTS;
                     }
+                    // Did we see at least one commit?
+                    if (latestPullTS > 0) return latestPullTS < super.getAcceptableDateTimeThreshold();
                 }
                 return false;
             } else if (scmHead instanceof GitHubTagSCMHead) {

--- a/github-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubAgedRefsTrait.java
+++ b/github-scm-filter-aged-refs/src/main/java/org/jenkinsci/plugins/scm_filter/GitHubAgedRefsTrait.java
@@ -101,7 +101,7 @@ public class GitHubAgedRefsTrait extends AgedRefsTrait {
                     if (iterator.hasNext()) {
                         long pullTS = iterator.next()
                                 .getCommit()
-                                .getAuthor()
+                                .getCommitter()
                                 .getDate()
                                 .getTime();
                         return pullTS < super.getAcceptableDateTimeThreshold();


### PR DESCRIPTION
This should fix a bug introduced with #43 (therefore only present in version [55.v9d01cee685e4](https://github.com/jenkinsci/scm-filter-aged-refs-plugin/releases/tag/55.v9d01cee685e4) where we assume the age of PRs is older then they actually are.

(This still might have a problem with PRs with more then 250 commits, but I don't know how to fix that without reintroducing #35...)

### Testing done

None yet.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
